### PR TITLE
fix: Jenkins Tests stage mount path for Docker-in-Docker workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,11 +26,15 @@ pipeline {
     stage('Tests') {
       steps {
         sh '''
-          docker run --rm -v "$PWD:/work" -w /work python:3.11-slim bash -lc "
-            pip install -U pip &&
-            pip install -r requirements.txt &&
-            pytest -q
-          "
+          set -e
+          docker run --rm \
+            -v jenkins_home:/var/jenkins_home \
+            -w "$WORKSPACE" \
+            python:3.11-slim bash -lc "
+              pip install -U pip &&
+              pip install -r requirements.txt &&
+              pytest -q
+            "
         '''
       }
     }


### PR DESCRIPTION
Contexto: El pipeline fallaba en el stage Tests con Could not open requirements file: requirements.txt.

Causa raíz: El comando usaba -v "$PWD:/work", pero en Jenkins corriendo en contenedor el $PWD no es un path válido/montable por el Docker daemon.

Cambio: Se ajusta el mount para usar el workspace real de Jenkins (ruta absoluta) y mantener -w /work para que pip install -r requirements.txt y pytest -q encuentren los archivos.

Validación: Pipeline ejecuta correctamente el stage Tests en Jenkins.

Issue relacionado
Closes #<ID_DEL_ISSUE_US-04>